### PR TITLE
Fix file renaming on windows systems

### DIFF
--- a/lib/multifile-rename.js
+++ b/lib/multifile-rename.js
@@ -76,9 +76,10 @@ export default {
 
       _.each(selectedFilePaths, function(path) {
         var folders = path.split(/(\/|\\)/);
+        var filename = folders.pop();
         selectedFiles.push({
-          "path": path.substring(0, path.lastIndexOf("/")),
-          "name": folders[folders.length-1]
+          "path": folders.join(''),
+          "name": filename
         });
       });
 


### PR DESCRIPTION
Fixes #6 

The path is already being correctly separated into `folders` with both separators, but we're only using this for the file name and not the file path.

This PR fixes this by popping the file name from the `folders` array and then `join`ing the rest of the array into the path, using whatever path separators the system uses.